### PR TITLE
Move QUndoStack import to QtGui

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -5,14 +5,13 @@ from pathlib import Path
 from typing import Optional
 
 from PySide6.QtCore import QPointF
-from PySide6.QtGui import QAction, QActionGroup
+from PySide6.QtGui import QAction, QActionGroup, QUndoStack
 from PySide6.QtWidgets import (
     QFileDialog,
     QInputDialog,
     QMainWindow,
     QMessageBox,
     QToolBar,
-    QUndoStack,
 )
 
 from gui.scene_view import GraphMode, GraphScene, GraphView


### PR DESCRIPTION
## Summary
- move the QUndoStack import from QtWidgets to the existing QtGui import list

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfe481dcec832b925969ea9f1d5400