### PR TITLE
Fix GraphView render hint usage

### DIFF
--- a/gui/scene_view.py
+++ b/gui/scene_view.py
@@ -5,7 +5,7 @@ from enum import Enum, auto
 from typing import Iterable, Optional
 
 from PySide6.QtCore import QPointF, QRectF, Signal
-from PySide6.QtGui import QTransform
+from PySide6.QtGui import QPainter, QTransform
 from PySide6.QtWidgets import QGraphicsScene, QGraphicsView
 
 from gui.edge_item import EdgeItem
@@ -92,7 +92,7 @@ class GraphView(QGraphicsView):
 
     def __init__(self, scene: GraphScene, parent=None) -> None:
         super().__init__(scene, parent)
-        self.setRenderHints(self.renderHints() | self.RenderHint.Antialiasing)
+        self.setRenderHints(self.renderHints() | QPainter.RenderHint.Antialiasing)
         self.setDragMode(self.DragMode.RubberBandDrag)
         self.setViewportUpdateMode(self.ViewportUpdateMode.BoundingRectViewportUpdate)
 


### PR DESCRIPTION
## Summary
- import QPainter in GraphView and use its RenderHint enum
- ensure antialiasing render hint is referenced correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfe56c58cc832b8a7d42399ec06812