### PR TITLE
Expand include directories for C++ modules

### DIFF
--- a/C++/visual_novel_editor/CMakeLists.txt
+++ b/C++/visual_novel_editor/CMakeLists.txt
@@ -12,6 +12,10 @@ add_subdirectory(src/export)
 
 add_executable(visual_novel_editor src/main.cpp)
 
+target_include_directories(visual_novel_editor
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
 target_link_libraries(visual_novel_editor
     PRIVATE
         GuiLib

--- a/C++/visual_novel_editor/src/export/CMakeLists.txt
+++ b/C++/visual_novel_editor/src/export/CMakeLists.txt
@@ -10,7 +10,10 @@ add_library(ExportLib STATIC ${EXPORT_SOURCES} ${EXPORT_HEADERS})
 
 set_target_properties(ExportLib PROPERTIES AUTOMOC ON)
 
-target_include_directories(ExportLib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(ExportLib
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 target_link_libraries(ExportLib
     PUBLIC ModelLib

--- a/C++/visual_novel_editor/src/gui/CMakeLists.txt
+++ b/C++/visual_novel_editor/src/gui/CMakeLists.txt
@@ -20,7 +20,10 @@ add_library(GuiLib STATIC ${GUI_SOURCES} ${GUI_HEADERS} ${GUI_RESOURCES})
 
 set_target_properties(GuiLib PROPERTIES AUTOMOC ON AUTORCC ON)
 
-target_include_directories(GuiLib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(GuiLib
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 target_link_libraries(GuiLib
     PUBLIC ModelLib

--- a/C++/visual_novel_editor/src/model/CMakeLists.txt
+++ b/C++/visual_novel_editor/src/model/CMakeLists.txt
@@ -13,7 +13,10 @@ add_library(ModelLib STATIC ${MODEL_SOURCES} ${MODEL_HEADERS})
 
 set_target_properties(ModelLib PROPERTIES AUTOMOC ON)
 
-target_include_directories(ModelLib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(ModelLib
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 target_link_libraries(ModelLib
     PUBLIC Qt6::Widgets)


### PR DESCRIPTION
## Summary
- expose the src tree to the executable target so headers under model and export resolve when included with their folder prefixes
- add the parent src directory to each static library's public include directories to make cross-module includes like model/... and export/... build cleanly

## Testing
- not run (Qt6 development files are not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e104cb3788832b8c8eb823366c4129