### PR TITLE
Enhance node inspector editing UI

### DIFF
--- a/C++/visual_novel_editor/src/export/ExporterRenpy.cpp
+++ b/C++/visual_novel_editor/src/export/ExporterRenpy.cpp
@@ -1,8 +1,10 @@
 #include "ExporterRenpy.h"
 
 #include <QFile>
-#include <QTextStream>
 #include <QStringList>
+#include <QTextDocument>
+#include <QTextStream>
+#include <Qt>
 
 #include "ScriptFormatter.h"
 #include "model/Choice.h"
@@ -51,7 +53,14 @@ void ExporterRenpy::generateNode(const QString &nodeId, QTextStream &out, int in
 
     out << "label " << nodeId << ":\n";
 
-    const QStringList lines = node->script().split('\n');
+    QTextDocument document;
+    const QString script = node->script();
+    if (Qt::mightBeRichText(script)) {
+        document.setHtml(script);
+    } else {
+        document.setPlainText(script);
+    }
+    const QStringList lines = document.toPlainText().split('\n');
     for (const QString &line : lines) {
         out << ScriptFormatter::indent(indent + 4) << line.trimmed() << '\n';
     }

--- a/C++/visual_novel_editor/src/gui/MainWindow.h
+++ b/C++/visual_novel_editor/src/gui/MainWindow.h
@@ -6,6 +6,7 @@ class GraphScene;
 class NodeInspectorWidget;
 class Project;
 class QGraphicsView;
+class QDockWidget;
 
 class MainWindow : public QMainWindow
 {
@@ -25,6 +26,7 @@ private slots:
     void editScript();
     void exportToRenpy();
     void onNodeSelected(const QString &nodeId);
+    void toggleInspectorExpanded(bool expanded);
 
 private:
     void createMenus();
@@ -34,6 +36,9 @@ private:
     GraphScene *m_scene{nullptr};
     QGraphicsView *m_view{nullptr};
     NodeInspectorWidget *m_inspector{nullptr};
+    QDockWidget *m_inspectorDock{nullptr};
+    QWidget *m_previousCentralWidget{nullptr};
+    bool m_isInspectorExpanded{false};
     Project *m_project{nullptr};
     QString m_currentProjectFile;
 };

--- a/C++/visual_novel_editor/src/gui/NodeInspectorWidget.h
+++ b/C++/visual_novel_editor/src/gui/NodeInspectorWidget.h
@@ -2,9 +2,15 @@
 
 #include <QWidget>
 
+class QAction;
+class QComboBox;
+class QToolBar;
+class QToolButton;
+
 class QLineEdit;
 class QTextEdit;
 class StoryNode;
+class QTextCharFormat;
 
 class NodeInspectorWidget : public QWidget
 {
@@ -13,18 +19,39 @@ public:
     explicit NodeInspectorWidget(QWidget *parent = nullptr);
 
     void setNode(StoryNode *node);
+    void setExpanded(bool expanded);
 
 signals:
     void nodeUpdated(const QString &nodeId);
+    void expandRequested(bool expanded);
 
 private slots:
     void onTitleEdited(const QString &text);
     void onScriptEdited();
+    void onExpandToggled(bool expanded);
+    void applyBold(bool enabled);
+    void applyItalic(bool enabled);
+    void applyUnderline(bool enabled);
+    void changeFontSize(const QString &sizeText);
+    void chooseTextColor();
+    void onCurrentCharFormatChanged(const QTextCharFormat &format);
 
 private:
     void refresh();
+    void updateExpandButtonAppearance();
+    void mergeFormatOnSelection(const QTextCharFormat &format);
+    void updateFormatControls(const QTextCharFormat &format);
 
     StoryNode *m_node{nullptr};
     QLineEdit *m_titleEdit{nullptr};
     QTextEdit *m_scriptEdit{nullptr};
+    QToolButton *m_expandButton{nullptr};
+    QToolBar *m_formatToolbar{nullptr};
+    QAction *m_boldAction{nullptr};
+    QAction *m_italicAction{nullptr};
+    QAction *m_underlineAction{nullptr};
+    QComboBox *m_fontSizeCombo{nullptr};
+    QToolButton *m_colorButton{nullptr};
+    bool m_isExpanded{false};
+    bool m_blockFormatSignals{false};
 };

--- a/C++/visual_novel_editor/src/gui/ScriptEditorDialog.cpp
+++ b/C++/visual_novel_editor/src/gui/ScriptEditorDialog.cpp
@@ -3,6 +3,7 @@
 #include <QDialogButtonBox>
 #include <QTextEdit>
 #include <QVBoxLayout>
+#include <Qt>
 
 #include "model/StoryNode.h"
 
@@ -22,14 +23,19 @@ ScriptEditorDialog::ScriptEditorDialog(StoryNode *node, QWidget *parent)
     connect(buttonBox, &QDialogButtonBox::rejected, this, &ScriptEditorDialog::reject);
 
     if (m_node) {
-        m_editor->setPlainText(m_node->script());
+        const QString script = m_node->script();
+        if (Qt::mightBeRichText(script)) {
+            m_editor->setHtml(script);
+        } else {
+            m_editor->setPlainText(script);
+        }
     }
 }
 
 void ScriptEditorDialog::accept()
 {
     if (m_node) {
-        m_node->setScript(m_editor->toPlainText());
+        m_node->setScript(m_editor->toHtml());
     }
     QDialog::accept();
 }


### PR DESCRIPTION
## Summary
- add an expandable inspector header and rich text formatting toolbar for node title and script editing
- let scripts persist as rich text and keep the standalone script editor in sync with HTML content
- update the Ren'Py exporter and main window wiring to support the new inspector workflow

## Testing
- cmake -S C++/visual_novel_editor -B build *(fails: Qt6 development files are unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e10d66e14c832b841e2aa59ea619cf