### PR TITLE
Add missing Qt includes for header declarations

### DIFF
--- a/C++/visual_novel_editor/src/gui/MainWindow.h
+++ b/C++/visual_novel_editor/src/gui/MainWindow.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QMainWindow>
+#include <QString>
 
 class GraphScene;
 class NodeInspectorWidget;

--- a/C++/visual_novel_editor/src/gui/NodeInspectorWidget.h
+++ b/C++/visual_novel_editor/src/gui/NodeInspectorWidget.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QString>
 #include <QWidget>
 
 class QAction;

--- a/C++/visual_novel_editor/src/gui/NodeItem.h
+++ b/C++/visual_novel_editor/src/gui/NodeItem.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <QGraphicsObject>
+#include <QPointF>
+#include <QString>
 
 class StoryNode;
 

--- a/C++/visual_novel_editor/src/model/Project.h
+++ b/C++/visual_novel_editor/src/model/Project.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QJsonObject>
 #include <QMap>
 #include <QObject>
 #include <QString>


### PR DESCRIPTION
## Summary
- include Qt types in headers that expose QString, QPointF, or QJsonObject
- ensure Qt meta-object macros see complete type information to avoid compilation failures

## Testing
- `cmake ../C++/visual_novel_editor` *(fails: missing Qt6 in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e111a1a1c8832ba5818097a8ef71a2