### PR TITLE
Fix EdgeItem forward declaration

### DIFF
--- a/C++/visual_novel_editor/src/gui/EdgeItem.h
+++ b/C++/visual_novel_editor/src/gui/EdgeItem.h
@@ -7,6 +7,8 @@
 class NodeItem;
 class Choice;
 
+class EditableLabelItem;
+
 class EdgeItem : public QGraphicsObject
 {
     Q_OBJECT
@@ -34,6 +36,6 @@ private:
     QString m_choiceId;
     QPainterPath m_path;
     QRectF m_boundingRect;
-    class EditableLabelItem *m_label{nullptr};
+    EditableLabelItem *m_label{nullptr};
     bool m_ignoreLabelSignal{false};
 };


### PR DESCRIPTION
## Summary
- add a standalone forward declaration for EditableLabelItem and use it to declare the EdgeItem label pointer
- resolve the incorrect nested class declaration that caused incomplete type compilation errors

## Testing
- not run (Qt6 development libraries not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e113d76090832ba486160761005e98