### PR TITLE
Add bilingual UI and improve graph editor interactions

### DIFF
--- a/C++/visual_novel_editor/src/gui/CMakeLists.txt
+++ b/C++/visual_novel_editor/src/gui/CMakeLists.txt
@@ -4,7 +4,8 @@ set(GUI_SOURCES
     NodeItem.cpp
     EdgeItem.cpp
     ScriptEditorDialog.cpp
-    NodeInspectorWidget.cpp)
+    NodeInspectorWidget.cpp
+    LanguageManager.cpp)
 
 set(GUI_HEADERS
     MainWindow.h
@@ -12,7 +13,8 @@ set(GUI_HEADERS
     NodeItem.h
     EdgeItem.h
     ScriptEditorDialog.h
-    NodeInspectorWidget.h)
+    NodeInspectorWidget.h
+    LanguageManager.h)
 
 qt6_add_resources(GUI_RESOURCES Icons.qrc)
 

--- a/C++/visual_novel_editor/src/gui/GraphScene.h
+++ b/C++/visual_novel_editor/src/gui/GraphScene.h
@@ -25,6 +25,7 @@ public:
 
 signals:
     void nodeSelected(const QString &nodeId);
+    void nodeDoubleClicked(const QString &nodeId);
 
 protected:
     void mousePressEvent(QGraphicsSceneMouseEvent *event) override;

--- a/C++/visual_novel_editor/src/gui/LanguageManager.cpp
+++ b/C++/visual_novel_editor/src/gui/LanguageManager.cpp
@@ -1,0 +1,151 @@
+#include "LanguageManager.h"
+
+#include <QCoreApplication>
+#include <QHash>
+#include <QTranslator>
+
+namespace {
+
+QString makeKey(const char *context, const char *sourceText)
+{
+    return QString::fromLatin1(context) + QLatin1Char('\004') + QString::fromUtf8(sourceText);
+}
+
+class InlineTranslator : public QTranslator
+{
+public:
+    InlineTranslator()
+    {
+        const QHash<QString, QString> translations = {
+            {makeKey("MainWindow", "&File"), QStringLiteral("文件(&F)")},
+            {makeKey("MainWindow", "&New"), QStringLiteral("新建(&N)")},
+            {makeKey("MainWindow", "&Open"), QStringLiteral("打开(&O)")},
+            {makeKey("MainWindow", "&Save"), QStringLiteral("保存(&S)")},
+            {makeKey("MainWindow", "E&xit"), QStringLiteral("退出(&X)")},
+            {makeKey("MainWindow", "&Edit"), QStringLiteral("编辑(&E)")},
+            {makeKey("MainWindow", "Add Node"), QStringLiteral("添加节点")},
+            {makeKey("MainWindow", "Delete"), QStringLiteral("删除")},
+            {makeKey("MainWindow", "Edit Script"), QStringLiteral("编辑脚本")},
+            {makeKey("MainWindow", "&Export"), QStringLiteral("导出(&E)")},
+            {makeKey("MainWindow", "Export to Ren'Py"), QStringLiteral("导出为 Ren'Py")},
+            {makeKey("MainWindow", "Tools"), QStringLiteral("工具")},
+            {makeKey("MainWindow", "Export"), QStringLiteral("导出")},
+            {makeKey("MainWindow", "Inspector"), QStringLiteral("检查器")},
+            {makeKey("MainWindow", "Ready"), QStringLiteral("就绪")},
+            {makeKey("MainWindow", "Created new project"), QStringLiteral("已创建新项目")},
+            {makeKey("MainWindow", "Open Project"), QStringLiteral("打开项目")},
+            {makeKey("MainWindow", "Project (*.json)"), QStringLiteral("项目文件 (*.json)")},
+            {makeKey("MainWindow", "Load Failed"), QStringLiteral("加载失败")},
+            {makeKey("MainWindow", "Unable to open project file."), QStringLiteral("无法打开项目文件。")},
+            {makeKey("MainWindow", "Project loaded"), QStringLiteral("项目已加载")},
+            {makeKey("MainWindow", "Save Project"), QStringLiteral("保存项目")},
+            {makeKey("MainWindow", "Save Failed"), QStringLiteral("保存失败")},
+            {makeKey("MainWindow", "Unable to write project file."), QStringLiteral("无法写入项目文件。")},
+            {makeKey("MainWindow", "Project saved"), QStringLiteral("项目已保存")},
+            {makeKey("MainWindow", "Dialogue"), QStringLiteral("对话")},
+            {makeKey("MainWindow", "# dialogue script"), QStringLiteral("# 对话脚本")},
+            {makeKey("MainWindow", "Node added"), QStringLiteral("节点已添加")},
+            {makeKey("MainWindow", "Export Ren'Py Script"), QStringLiteral("导出 Ren'Py 脚本")},
+            {makeKey("MainWindow", "Ren'Py Script (*.rpy)"), QStringLiteral("Ren'Py 脚本 (*.rpy)")},
+            {makeKey("MainWindow", "Export Failed"), QStringLiteral("导出失败")},
+            {makeKey("MainWindow", "Could not export Ren'Py script."), QStringLiteral("无法导出 Ren'Py 脚本。")},
+            {makeKey("MainWindow", "Exported to Ren'Py"), QStringLiteral("已导出至 Ren'Py")},
+            {makeKey("MainWindow", "Settings"), QStringLiteral("设置")},
+            {makeKey("MainWindow", "Language"), QStringLiteral("语言")},
+            {makeKey("MainWindow", "English"), QStringLiteral("英语")},
+            {makeKey("MainWindow", "Chinese"), QStringLiteral("中文")},
+            {makeKey("MainWindow", "OK"), QStringLiteral("确定")},
+            {makeKey("MainWindow", "Cancel"), QStringLiteral("取消")},
+            {makeKey("GraphScene", "Copy"), QStringLiteral("复制")},
+            {makeKey("GraphScene", "Cut"), QStringLiteral("剪切")},
+            {makeKey("GraphScene", "Delete"), QStringLiteral("删除")},
+            {makeKey("GraphScene", "Create Branch"), QStringLiteral("创建分支")},
+            {makeKey("GraphScene", "Add Node"), QStringLiteral("添加节点")},
+            {makeKey("NodeInspectorWidget", "Node Inspector"), QStringLiteral("节点检查器")},
+            {makeKey("NodeInspectorWidget", "Expand inspector to full window"), QStringLiteral("将检查器扩展为全窗口")},
+            {makeKey("NodeInspectorWidget", "Restore inspector to sidebar"), QStringLiteral("将检查器还原到侧栏")},
+            {makeKey("NodeInspectorWidget", "Title"), QStringLiteral("标题")},
+            {makeKey("NodeInspectorWidget", "B"), QStringLiteral("B")},
+            {makeKey("NodeInspectorWidget", "I"), QStringLiteral("I")},
+            {makeKey("NodeInspectorWidget", "U"), QStringLiteral("U")},
+            {makeKey("NodeInspectorWidget", "Color"), QStringLiteral("颜色")},
+            {makeKey("NodeInspectorWidget", "Select Text Color"), QStringLiteral("选择文本颜色")},
+            {makeKey("ScriptEditorDialog", "Script Editor"), QStringLiteral("脚本编辑器")},
+            {makeKey("ScriptEditorDialog", "OK"), QStringLiteral("确定")},
+            {makeKey("ScriptEditorDialog", "Cancel"), QStringLiteral("取消")},
+        };
+
+        m_translations = translations;
+    }
+
+    QString translate(const char *context, const char *sourceText,
+                       const char *disambiguation, int n) const override
+    {
+        Q_UNUSED(disambiguation);
+        Q_UNUSED(n);
+        if (!context || !sourceText) {
+            return {};
+        }
+        const QString key = makeKey(context, sourceText);
+        const auto it = m_translations.constFind(key);
+        if (it != m_translations.cend()) {
+            return *it;
+        }
+        return {};
+    }
+
+private:
+    QHash<QString, QString> m_translations;
+};
+
+} // namespace
+
+LanguageManager &LanguageManager::instance()
+{
+    static LanguageManager manager;
+    return manager;
+}
+
+LanguageManager::LanguageManager()
+    : QObject(nullptr)
+    , m_chineseTranslator(std::make_unique<InlineTranslator>())
+{
+}
+
+void LanguageManager::initialize(QCoreApplication *app)
+{
+    m_app = app;
+    if (m_app && m_language == Language::Chinese) {
+        m_app->installTranslator(m_chineseTranslator.get());
+    }
+}
+
+void LanguageManager::setLanguage(Language language)
+{
+    if (language == m_language) {
+        return;
+    }
+    m_language = language;
+
+    if (!m_app) {
+        emit languageChanged(m_language);
+        return;
+    }
+
+    if (m_language == Language::Chinese) {
+        if (!m_app->installTranslator(m_chineseTranslator.get())) {
+            emit languageChanged(m_language);
+            return;
+        }
+    } else {
+        m_app->removeTranslator(m_chineseTranslator.get());
+    }
+
+    emit languageChanged(m_language);
+}
+
+LanguageManager::Language LanguageManager::language() const
+{
+    return m_language;
+}
+

--- a/C++/visual_novel_editor/src/gui/LanguageManager.h
+++ b/C++/visual_novel_editor/src/gui/LanguageManager.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <QObject>
+#include <memory>
+
+class QCoreApplication;
+
+class LanguageManager : public QObject
+{
+    Q_OBJECT
+public:
+    enum class Language {
+        English,
+        Chinese,
+    };
+
+    static LanguageManager &instance();
+
+    void initialize(QCoreApplication *app);
+
+    Language language() const;
+    void setLanguage(Language language);
+
+signals:
+    void languageChanged(Language language);
+
+private:
+    class InlineTranslator;
+
+    LanguageManager();
+
+    QCoreApplication *m_app{nullptr};
+    std::unique_ptr<InlineTranslator> m_chineseTranslator;
+    Language m_language{Language::English};
+};
+

--- a/C++/visual_novel_editor/src/gui/MainWindow.h
+++ b/C++/visual_novel_editor/src/gui/MainWindow.h
@@ -3,11 +3,18 @@
 #include <QMainWindow>
 #include <QString>
 
+#include "LanguageManager.h"
+
 class GraphScene;
 class NodeInspectorWidget;
 class Project;
 class QGraphicsView;
 class QDockWidget;
+class StoryNode;
+class QMenu;
+class QToolBar;
+class QAction;
+class QActionGroup;
 
 class MainWindow : public QMainWindow
 {
@@ -17,6 +24,9 @@ public:
     ~MainWindow() override;
 
     void setProject(Project *project);
+
+protected:
+    void changeEvent(QEvent *event) override;
 
 private slots:
     void newProject();
@@ -28,18 +38,46 @@ private slots:
     void exportToRenpy();
     void onNodeSelected(const QString &nodeId);
     void toggleInspectorExpanded(bool expanded);
+    void onNodeDoubleClicked(const QString &nodeId);
 
 private:
     void createMenus();
     void createToolbars();
     void setupScene();
+    void retranslateUi();
+    void updateLanguageMenuState();
+    void openScriptEditorForNode(StoryNode *node);
+    void setStatusMessage(const QString &key, int timeoutMs = 0);
 
     GraphScene *m_scene{nullptr};
     QGraphicsView *m_view{nullptr};
     NodeInspectorWidget *m_inspector{nullptr};
     QDockWidget *m_inspectorDock{nullptr};
     QWidget *m_previousCentralWidget{nullptr};
-    bool m_isInspectorExpanded{false};
     Project *m_project{nullptr};
     QString m_currentProjectFile;
+    bool m_isInspectorExpanded{false};
+
+    QMenu *m_fileMenu{nullptr};
+    QMenu *m_editMenu{nullptr};
+    QMenu *m_exportMenu{nullptr};
+    QMenu *m_settingsMenu{nullptr};
+    QMenu *m_languageMenu{nullptr};
+    QToolBar *m_mainToolbar{nullptr};
+
+    QAction *m_newAction{nullptr};
+    QAction *m_openAction{nullptr};
+    QAction *m_saveAction{nullptr};
+    QAction *m_exitAction{nullptr};
+    QAction *m_addNodeAction{nullptr};
+    QAction *m_deleteAction{nullptr};
+    QAction *m_editScriptAction{nullptr};
+    QAction *m_exportRenpyAction{nullptr};
+
+    QActionGroup *m_languageGroup{nullptr};
+    QAction *m_languageEnglishAction{nullptr};
+    QAction *m_languageChineseAction{nullptr};
+
+    QString m_lastStatusKey;
+    int m_lastStatusTimeout{0};
 };

--- a/C++/visual_novel_editor/src/gui/NodeInspectorWidget.cpp
+++ b/C++/visual_novel_editor/src/gui/NodeInspectorWidget.cpp
@@ -5,6 +5,7 @@
 #include <QColor>
 #include <QColorDialog>
 #include <QComboBox>
+#include <QEvent>
 #include <QFont>
 #include <QFontDatabase>
 #include <QFormLayout>
@@ -34,20 +35,20 @@ NodeInspectorWidget::NodeInspectorWidget(QWidget *parent)
     mainLayout->setSpacing(8);
 
     auto *headerLayout = new QHBoxLayout;
-    auto *titleLabel = new QLabel(tr("Node Inspector"), this);
-    titleLabel->setStyleSheet(QStringLiteral("font-weight: bold;"));
-    headerLayout->addWidget(titleLabel);
+    m_headerLabel = new QLabel(this);
+    m_headerLabel->setStyleSheet(QStringLiteral("font-weight: bold;"));
+    headerLayout->addWidget(m_headerLabel);
     headerLayout->addStretch();
     m_expandButton = new QToolButton(this);
     m_expandButton->setCheckable(true);
     m_expandButton->setAutoRaise(true);
-    m_expandButton->setToolTip(tr("Expand inspector to full window"));
     m_expandButton->setText(QStringLiteral("⤢"));
     headerLayout->addWidget(m_expandButton);
     mainLayout->addLayout(headerLayout);
 
     auto *formLayout = new QFormLayout;
-    formLayout->addRow(tr("Title"), m_titleEdit);
+    m_titleLabel = new QLabel(this);
+    formLayout->addRow(m_titleLabel, m_titleEdit);
     mainLayout->addLayout(formLayout);
 
     m_formatToolbar = new QToolBar(this);
@@ -55,19 +56,19 @@ NodeInspectorWidget::NodeInspectorWidget(QWidget *parent)
     m_formatToolbar->setMovable(false);
     m_formatToolbar->setFloatable(false);
 
-    m_boldAction = m_formatToolbar->addAction(tr("B"));
+    m_boldAction = m_formatToolbar->addAction(QString());
     QFont boldFont = font();
     boldFont.setBold(true);
     m_boldAction->setFont(boldFont);
     m_boldAction->setCheckable(true);
 
-    m_italicAction = m_formatToolbar->addAction(tr("I"));
+    m_italicAction = m_formatToolbar->addAction(QString());
     QFont italicFont = font();
     italicFont.setItalic(true);
     m_italicAction->setFont(italicFont);
     m_italicAction->setCheckable(true);
 
-    m_underlineAction = m_formatToolbar->addAction(tr("U"));
+    m_underlineAction = m_formatToolbar->addAction(QString());
     QFont underlineFont = font();
     underlineFont.setUnderline(true);
     m_underlineAction->setFont(underlineFont);
@@ -76,7 +77,6 @@ NodeInspectorWidget::NodeInspectorWidget(QWidget *parent)
     m_formatToolbar->addSeparator();
 
     m_colorButton = new QToolButton(this);
-    m_colorButton->setText(tr("Color"));
     m_colorButton->setAutoRaise(true);
     m_formatToolbar->addWidget(m_colorButton);
 
@@ -108,6 +108,8 @@ NodeInspectorWidget::NodeInspectorWidget(QWidget *parent)
     connect(m_colorButton, &QToolButton::clicked, this, &NodeInspectorWidget::chooseTextColor);
 
     m_scriptEdit->setAcceptRichText(true);
+
+    retranslateUi();
 }
 
 void NodeInspectorWidget::setNode(StoryNode *node)
@@ -246,13 +248,10 @@ void NodeInspectorWidget::updateExpandButtonAppearance()
     if (!m_expandButton) {
         return;
     }
-    if (m_isExpanded) {
-        m_expandButton->setText(QStringLiteral("⤺"));
-        m_expandButton->setToolTip(tr("Restore inspector to sidebar"));
-    } else {
-        m_expandButton->setText(QStringLiteral("⤢"));
-        m_expandButton->setToolTip(tr("Expand inspector to full window"));
-    }
+    m_expandButton->setText(m_isExpanded ? QStringLiteral("⤡") : QStringLiteral("⤢"));
+    const QString tooltip = m_isExpanded ? tr("Restore inspector to sidebar")
+                                         : tr("Expand inspector to full window");
+    m_expandButton->setToolTip(tooltip);
 }
 
 void NodeInspectorWidget::mergeFormatOnSelection(const QTextCharFormat &format)
@@ -301,4 +300,35 @@ void NodeInspectorWidget::updateFormatControls(const QTextCharFormat &format)
     }
 
     m_blockFormatSignals = false;
+}
+
+void NodeInspectorWidget::changeEvent(QEvent *event)
+{
+    if (event->type() == QEvent::LanguageChange) {
+        retranslateUi();
+    }
+    QWidget::changeEvent(event);
+}
+
+void NodeInspectorWidget::retranslateUi()
+{
+    if (m_headerLabel) {
+        m_headerLabel->setText(tr("Node Inspector"));
+    }
+    if (m_titleLabel) {
+        m_titleLabel->setText(tr("Title"));
+    }
+    if (m_boldAction) {
+        m_boldAction->setText(tr("B"));
+    }
+    if (m_italicAction) {
+        m_italicAction->setText(tr("I"));
+    }
+    if (m_underlineAction) {
+        m_underlineAction->setText(tr("U"));
+    }
+    if (m_colorButton) {
+        m_colorButton->setText(tr("Color"));
+    }
+    updateExpandButtonAppearance();
 }

--- a/C++/visual_novel_editor/src/gui/NodeInspectorWidget.h
+++ b/C++/visual_novel_editor/src/gui/NodeInspectorWidget.h
@@ -7,6 +7,7 @@ class QAction;
 class QComboBox;
 class QToolBar;
 class QToolButton;
+class QLabel;
 
 class QLineEdit;
 class QTextEdit;
@@ -37,11 +38,15 @@ private slots:
     void chooseTextColor();
     void onCurrentCharFormatChanged(const QTextCharFormat &format);
 
+protected:
+    void changeEvent(QEvent *event) override;
+
 private:
     void refresh();
     void updateExpandButtonAppearance();
     void mergeFormatOnSelection(const QTextCharFormat &format);
     void updateFormatControls(const QTextCharFormat &format);
+    void retranslateUi();
 
     StoryNode *m_node{nullptr};
     QLineEdit *m_titleEdit{nullptr};
@@ -53,6 +58,8 @@ private:
     QAction *m_underlineAction{nullptr};
     QComboBox *m_fontSizeCombo{nullptr};
     QToolButton *m_colorButton{nullptr};
+    QLabel *m_headerLabel{nullptr};
+    QLabel *m_titleLabel{nullptr};
     bool m_isExpanded{false};
     bool m_blockFormatSignals{false};
 };

--- a/C++/visual_novel_editor/src/gui/ScriptEditorDialog.cpp
+++ b/C++/visual_novel_editor/src/gui/ScriptEditorDialog.cpp
@@ -1,6 +1,8 @@
 #include "ScriptEditorDialog.h"
 
 #include <QDialogButtonBox>
+#include <QEvent>
+#include <QPushButton>
 #include <QTextEdit>
 #include <QVBoxLayout>
 #include <Qt>
@@ -12,15 +14,14 @@ ScriptEditorDialog::ScriptEditorDialog(StoryNode *node, QWidget *parent)
     , m_node(node)
     , m_editor(new QTextEdit(this))
 {
-    setWindowTitle(tr("Script Editor"));
     auto *layout = new QVBoxLayout(this);
     layout->addWidget(m_editor);
 
-    auto *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
-    layout->addWidget(buttonBox);
+    m_buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    layout->addWidget(m_buttonBox);
 
-    connect(buttonBox, &QDialogButtonBox::accepted, this, &ScriptEditorDialog::accept);
-    connect(buttonBox, &QDialogButtonBox::rejected, this, &ScriptEditorDialog::reject);
+    connect(m_buttonBox, &QDialogButtonBox::accepted, this, &ScriptEditorDialog::accept);
+    connect(m_buttonBox, &QDialogButtonBox::rejected, this, &ScriptEditorDialog::reject);
 
     if (m_node) {
         const QString script = m_node->script();
@@ -30,6 +31,8 @@ ScriptEditorDialog::ScriptEditorDialog(StoryNode *node, QWidget *parent)
             m_editor->setPlainText(script);
         }
     }
+
+    retranslateUi();
 }
 
 void ScriptEditorDialog::accept()
@@ -38,4 +41,25 @@ void ScriptEditorDialog::accept()
         m_node->setScript(m_editor->toHtml());
     }
     QDialog::accept();
+}
+
+void ScriptEditorDialog::changeEvent(QEvent *event)
+{
+    if (event->type() == QEvent::LanguageChange) {
+        retranslateUi();
+    }
+    QDialog::changeEvent(event);
+}
+
+void ScriptEditorDialog::retranslateUi()
+{
+    setWindowTitle(tr("Script Editor"));
+    if (m_buttonBox) {
+        if (QPushButton *okButton = m_buttonBox->button(QDialogButtonBox::Ok)) {
+            okButton->setText(tr("OK"));
+        }
+        if (QPushButton *cancelButton = m_buttonBox->button(QDialogButtonBox::Cancel)) {
+            cancelButton->setText(tr("Cancel"));
+        }
+    }
 }

--- a/C++/visual_novel_editor/src/gui/ScriptEditorDialog.h
+++ b/C++/visual_novel_editor/src/gui/ScriptEditorDialog.h
@@ -13,8 +13,12 @@ public:
 
 protected:
     void accept() override;
+    void changeEvent(QEvent *event) override;
 
 private:
+    void retranslateUi();
+
     StoryNode *m_node{nullptr};
     QTextEdit *m_editor{nullptr};
+    QDialogButtonBox *m_buttonBox{nullptr};
 };

--- a/C++/visual_novel_editor/src/main.cpp
+++ b/C++/visual_novel_editor/src/main.cpp
@@ -1,4 +1,6 @@
 #include <QApplication>
+
+#include "gui/LanguageManager.h"
 #include "gui/MainWindow.h"
 #include "model/Project.h"
 
@@ -6,8 +8,9 @@ int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
 
+    LanguageManager::instance().initialize(&app);
+
     Project project;
-    // TODO: load project if filename provided via argv
 
     MainWindow mainWindow;
     mainWindow.setProject(&project);


### PR DESCRIPTION
## Summary
- add a LanguageManager with Chinese translations and hook it into the application start-up
- expose a Settings > Language menu, retranslate the main window, and update widgets/dialogs to react to language changes
- fix graph interactions by handling node double-clicks for the script editor and adding a safe context menu option on blank areas

## Testing
- cmake -S C++/visual_novel_editor -B C++/visual_novel_editor/build *(fails: missing Qt6 development files in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1173c1e30832b84b4b790e3ba9afe