### PR TITLE
Fix InlineTranslator forward declaration

### DIFF
--- a/C++/visual_novel_editor/src/gui/LanguageManager.h
+++ b/C++/visual_novel_editor/src/gui/LanguageManager.h
@@ -5,6 +5,8 @@
 
 class QCoreApplication;
 
+class InlineTranslator;
+
 class LanguageManager : public QObject
 {
     Q_OBJECT
@@ -25,8 +27,6 @@ signals:
     void languageChanged(Language language);
 
 private:
-    class InlineTranslator;
-
     LanguageManager();
 
     QCoreApplication *m_app{nullptr};


### PR DESCRIPTION
## Summary
- forward declare the InlineTranslator helper outside of the LanguageManager class so the definition in the implementation file matches the declaration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e11f5dca60832bbd29149f7c9630b7