### PR TITLE
Fix InlineTranslator definition for LanguageManager

### DIFF
--- a/C++/visual_novel_editor/src/gui/LanguageManager.cpp
+++ b/C++/visual_novel_editor/src/gui/LanguageManager.cpp
@@ -11,7 +11,9 @@ QString makeKey(const char *context, const char *sourceText)
     return QString::fromLatin1(context) + QLatin1Char('\004') + QString::fromUtf8(sourceText);
 }
 
-class InlineTranslator : public QTranslator
+} // namespace
+
+class LanguageManager::InlineTranslator : public QTranslator
 {
 public:
     InlineTranslator()
@@ -97,8 +99,6 @@ public:
 private:
     QHash<QString, QString> m_translations;
 };
-
-} // namespace
 
 LanguageManager &LanguageManager::instance()
 {


### PR DESCRIPTION
## Summary
- define LanguageManager::InlineTranslator so the header and implementation agree

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e120224850832b93ffef1e3348291d