### PR TITLE
Fix InlineTranslator linkage issue

### DIFF
--- a/C++/visual_novel_editor/src/gui/LanguageManager.h
+++ b/C++/visual_novel_editor/src/gui/LanguageManager.h
@@ -1,11 +1,10 @@
 #pragma once
 
 #include <QObject>
+#include <QTranslator>
 #include <memory>
 
 class QCoreApplication;
-
-class InlineTranslator;
 
 class LanguageManager : public QObject
 {
@@ -30,7 +29,7 @@ private:
     LanguageManager();
 
     QCoreApplication *m_app{nullptr};
-    std::unique_ptr<InlineTranslator> m_chineseTranslator;
+    std::unique_ptr<QTranslator> m_chineseTranslator;
     Language m_language{Language::English};
 };
 


### PR DESCRIPTION
## Summary
- update LanguageManager to hold a QTranslator instance via unique_ptr
- include the QTranslator header to ensure the type is complete

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1212b15e8832bb236fce7f11920e3