### PR TITLE
Fix missing QDialogButtonBox declaration

### DIFF
--- a/C++/visual_novel_editor/src/gui/ScriptEditorDialog.h
+++ b/C++/visual_novel_editor/src/gui/ScriptEditorDialog.h
@@ -2,6 +2,7 @@
 
 #include <QDialog>
 
+class QDialogButtonBox;
 class QTextEdit;
 class StoryNode;
 


### PR DESCRIPTION
## Summary
- forward declare QDialogButtonBox in ScriptEditorDialog header to resolve missing type errors

## Testing
- not run (Qt build environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e12232a394832b85dc79cf21aee448