### PR TITLE
Use smart pointers for project nodes

### DIFF
--- a/C++/visual_novel_editor/src/gui/GraphScene.cpp
+++ b/C++/visual_novel_editor/src/gui/GraphScene.cpp
@@ -168,7 +168,11 @@ void GraphScene::rebuild()
         return;
     }
 
-    for (StoryNode *node : m_project->nodes()) {
+    for (auto it = m_project->nodes().cbegin(); it != m_project->nodes().cend(); ++it) {
+        StoryNode *node = it.value().get();
+        if (!node) {
+            continue;
+        }
         NodeItem *item = createNodeItem(node);
         addItem(item);
         item->setPos(node->position());
@@ -217,7 +221,11 @@ void GraphScene::rebuildEdges()
         return;
     }
 
-    for (StoryNode *node : m_project->nodes()) {
+    for (auto it = m_project->nodes().cbegin(); it != m_project->nodes().cend(); ++it) {
+        StoryNode *node = it.value().get();
+        if (!node) {
+            continue;
+        }
         NodeItem *sourceItem = m_nodeItems.value(node->id(), nullptr);
         if (!sourceItem) {
             continue;
@@ -393,7 +401,11 @@ void GraphScene::deleteNodes(const QList<NodeItem *> &nodes)
 
     const QSet<QString> idSet(ids.cbegin(), ids.cend());
 
-    for (StoryNode *node : m_project->nodes()) {
+    for (auto it = m_project->nodes().cbegin(); it != m_project->nodes().cend(); ++it) {
+        StoryNode *node = it.value().get();
+        if (!node) {
+            continue;
+        }
         auto &choices = node->choices();
         for (int i = choices.size() - 1; i >= 0; --i) {
             if (idSet.contains(choices[i].targetNodeId)) {
@@ -412,7 +424,11 @@ Choice *GraphScene::findChoice(const QString &choiceId)
     if (!m_project) {
         return nullptr;
     }
-    for (StoryNode *node : m_project->nodes()) {
+    for (auto it = m_project->nodes().cbegin(); it != m_project->nodes().cend(); ++it) {
+        StoryNode *node = it.value().get();
+        if (!node) {
+            continue;
+        }
         auto &choices = node->choices();
         for (Choice &choice : choices) {
             if (choice.id == choiceId) {

--- a/C++/visual_novel_editor/src/model/Project.h
+++ b/C++/visual_novel_editor/src/model/Project.h
@@ -5,6 +5,8 @@
 #include <QObject>
 #include <QString>
 
+#include <memory>
+
 #include "StoryNode.h"
 
 class Project : public QObject
@@ -12,15 +14,13 @@ class Project : public QObject
     Q_OBJECT
 public:
     explicit Project(QObject *parent = nullptr);
-    ~Project() override;
-
     StoryNode *addNode(StoryNode::Type type);
     void removeNode(const QString &nodeId);
     void clear();
 
     StoryNode *getNode(const QString &nodeId);
     const StoryNode *getNode(const QString &nodeId) const;
-    const QMap<QString, StoryNode *> &nodes() const { return m_nodes; }
+    const QMap<QString, std::unique_ptr<StoryNode>> &nodes() const { return m_nodes; }
 
     [[nodiscard]] bool loadFromFile(const QString &fileName);
     [[nodiscard]] bool saveToFile(const QString &fileName) const;
@@ -31,7 +31,7 @@ signals:
     void changed();
 
 private:
-    QMap<QString, StoryNode *> m_nodes;
+    QMap<QString, std::unique_ptr<StoryNode>> m_nodes;
 
     QJsonObject toJson() const;
     void fromJson(const QJsonObject &json);


### PR DESCRIPTION
## Summary
- store story nodes in `Project` using `std::unique_ptr` and remove manual deletion
- update project CRUD and JSON serialization logic to create nodes via `std::make_unique`
- adjust graph scene iteration to access raw node pointers from the smart-pointer map

## Testing
- cmake -S C++/visual_novel_editor -B build *(fails: Qt6 not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e127681e24832ba4e29a465acc105e