### PR TITLE
Use QPointer to guard scene items

### DIFF
--- a/C++/visual_novel_editor/src/gui/GraphScene.h
+++ b/C++/visual_novel_editor/src/gui/GraphScene.h
@@ -3,6 +3,7 @@
 #include <QGraphicsScene>
 #include <QHash>
 #include <QList>
+#include <QPointer>
 #include <QPointF>
 #include <QString>
 
@@ -51,7 +52,7 @@ private:
     void rebuild();
 
     Project *m_project{nullptr};
-    QHash<QString, NodeItem *> m_nodeItems;
-    QList<EdgeItem *> m_edgeItems;
-    NodeItem *m_pendingBranchSource{nullptr};
+    QHash<QString, QPointer<NodeItem>> m_nodeItems;
+    QList<QPointer<EdgeItem>> m_edgeItems;
+    QPointer<NodeItem> m_pendingBranchSource;
 };


### PR DESCRIPTION
## Summary
- replace cached raw scene item pointers with QPointer wrappers and include the proper header
- adjust rebuild, edge maintenance, and branch handling to respect QObject ownership and skip deleted items

## Testing
- cmake -S C++/visual_novel_editor -B C++/visual_novel_editor/build *(fails: Qt6Config.cmake not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e12a0478a8832ba76890862fb52b98