### PR TITLE
Add icons and tooltips to editor actions

### DIFF
--- a/C++/visual_novel_editor/src/gui/Icons.qrc
+++ b/C++/visual_novel_editor/src/gui/Icons.qrc
@@ -1,5 +1,11 @@
 <RCC>
     <qresource prefix="/icons">
-        <!-- Placeholder for future icon resources -->
+        <file alias="add_node.svg">../../../../resources/add_node.svg</file>
+        <file alias="edit_script.svg">../../../../resources/edit_script.svg</file>
+        <file alias="export.svg">../../../../resources/export.svg</file>
+        <file alias="text_bold.svg">../../../../resources/text_bold.svg</file>
+        <file alias="text_italic.svg">../../../../resources/text_italic.svg</file>
+        <file alias="text_underline.svg">../../../../resources/text_underline.svg</file>
+        <file alias="palette.svg">../../../../resources/palette.svg</file>
     </qresource>
 </RCC>

--- a/C++/visual_novel_editor/src/gui/MainWindow.cpp
+++ b/C++/visual_novel_editor/src/gui/MainWindow.cpp
@@ -9,6 +9,7 @@
 #include <QFileDialog>
 #include <QGraphicsItem>
 #include <QGraphicsView>
+#include <QIcon>
 #include <QMenu>
 #include <QMenuBar>
 #include <QMessageBox>
@@ -74,11 +75,17 @@ void MainWindow::createMenus()
 
     m_editMenu = menuBar()->addMenu(QString());
     m_addNodeAction = m_editMenu->addAction(QString(), this, &MainWindow::addNode);
+    m_addNodeAction->setIcon(QIcon(QStringLiteral(":/icons/add_node.svg")));
+    m_addNodeAction->setShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_N));
     m_deleteAction = m_editMenu->addAction(QString(), this, &MainWindow::deleteSelection);
     m_editScriptAction = m_editMenu->addAction(QString(), this, &MainWindow::editScript);
+    m_editScriptAction->setIcon(QIcon(QStringLiteral(":/icons/edit_script.svg")));
+    m_editScriptAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_E));
 
     m_exportMenu = menuBar()->addMenu(QString());
     m_exportRenpyAction = m_exportMenu->addAction(QString(), this, &MainWindow::exportToRenpy);
+    m_exportRenpyAction->setIcon(QIcon(QStringLiteral(":/icons/export.svg")));
+    m_exportRenpyAction->setShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_R));
 
     m_settingsMenu = menuBar()->addMenu(QString());
     m_languageMenu = m_settingsMenu->addMenu(QString());
@@ -318,12 +325,22 @@ void MainWindow::retranslateUi()
     }
     if (m_addNodeAction) {
         m_addNodeAction->setText(tr("Add Node"));
+        const QString shortcutText = m_addNodeAction->shortcut().toString(QKeySequence::NativeText);
+        const QString tip = shortcutText.isEmpty() ? tr("Create a new story node")
+                                                   : tr("Create a new story node (%1)").arg(shortcutText);
+        m_addNodeAction->setToolTip(tip);
+        m_addNodeAction->setStatusTip(tip);
     }
     if (m_deleteAction) {
         m_deleteAction->setText(tr("Delete"));
     }
     if (m_editScriptAction) {
         m_editScriptAction->setText(tr("Edit Script"));
+        const QString shortcutText = m_editScriptAction->shortcut().toString(QKeySequence::NativeText);
+        const QString tip = shortcutText.isEmpty() ? tr("Open the script editor for the selected node")
+                                                   : tr("Open the script editor for the selected node (%1)").arg(shortcutText);
+        m_editScriptAction->setToolTip(tip);
+        m_editScriptAction->setStatusTip(tip);
     }
 
     if (m_exportMenu) {
@@ -331,6 +348,11 @@ void MainWindow::retranslateUi()
     }
     if (m_exportRenpyAction) {
         m_exportRenpyAction->setText(tr("Export to Ren'Py"));
+        const QString shortcutText = m_exportRenpyAction->shortcut().toString(QKeySequence::NativeText);
+        const QString tip = shortcutText.isEmpty() ? tr("Generate a Ren'Py project from the current story")
+                                                   : tr("Generate a Ren'Py project from the current story (%1)").arg(shortcutText);
+        m_exportRenpyAction->setToolTip(tip);
+        m_exportRenpyAction->setStatusTip(tip);
     }
 
     if (m_settingsMenu) {

--- a/C++/visual_novel_editor/src/gui/NodeInspectorWidget.cpp
+++ b/C++/visual_novel_editor/src/gui/NodeInspectorWidget.cpp
@@ -10,7 +10,9 @@
 #include <QFontDatabase>
 #include <QFormLayout>
 #include <QHBoxLayout>
+#include <QIcon>
 #include <QIntValidator>
+#include <QKeySequence>
 #include <QLabel>
 #include <QLineEdit>
 #include <QSignalBlocker>
@@ -18,6 +20,7 @@
 #include <QTextCharFormat>
 #include <QTextCursor>
 #include <QTextEdit>
+#include <QStyle>
 #include <QToolBar>
 #include <QToolButton>
 #include <QVBoxLayout>
@@ -42,7 +45,7 @@ NodeInspectorWidget::NodeInspectorWidget(QWidget *parent)
     m_expandButton = new QToolButton(this);
     m_expandButton->setCheckable(true);
     m_expandButton->setAutoRaise(true);
-    m_expandButton->setText(QStringLiteral("⤢"));
+    m_expandButton->setIconSize(QSize(16, 16));
     headerLayout->addWidget(m_expandButton);
     mainLayout->addLayout(headerLayout);
 
@@ -57,18 +60,27 @@ NodeInspectorWidget::NodeInspectorWidget(QWidget *parent)
     m_formatToolbar->setFloatable(false);
 
     m_boldAction = m_formatToolbar->addAction(QString());
+    m_boldAction->setIcon(QIcon(QStringLiteral(":/icons/text_bold.svg")));
+    m_boldAction->setShortcut(QKeySequence::Bold);
+    m_boldAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     QFont boldFont = font();
     boldFont.setBold(true);
     m_boldAction->setFont(boldFont);
     m_boldAction->setCheckable(true);
 
     m_italicAction = m_formatToolbar->addAction(QString());
+    m_italicAction->setIcon(QIcon(QStringLiteral(":/icons/text_italic.svg")));
+    m_italicAction->setShortcut(QKeySequence::Italic);
+    m_italicAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     QFont italicFont = font();
     italicFont.setItalic(true);
     m_italicAction->setFont(italicFont);
     m_italicAction->setCheckable(true);
 
     m_underlineAction = m_formatToolbar->addAction(QString());
+    m_underlineAction->setIcon(QIcon(QStringLiteral(":/icons/text_underline.svg")));
+    m_underlineAction->setShortcut(QKeySequence::Underline);
+    m_underlineAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     QFont underlineFont = font();
     underlineFont.setUnderline(true);
     m_underlineAction->setFont(underlineFont);
@@ -77,6 +89,7 @@ NodeInspectorWidget::NodeInspectorWidget(QWidget *parent)
     m_formatToolbar->addSeparator();
 
     m_colorButton = new QToolButton(this);
+    m_colorButton->setIcon(QIcon(QStringLiteral(":/icons/palette.svg")));
     m_colorButton->setAutoRaise(true);
     m_formatToolbar->addWidget(m_colorButton);
 
@@ -248,10 +261,14 @@ void NodeInspectorWidget::updateExpandButtonAppearance()
     if (!m_expandButton) {
         return;
     }
-    m_expandButton->setText(m_isExpanded ? QStringLiteral("⤡") : QStringLiteral("⤢"));
+    m_expandButton->setIcon(style()->standardIcon(m_isExpanded ? QStyle::SP_TitleBarNormalButton
+                                                              : QStyle::SP_TitleBarMaxButton));
+    m_expandButton->setText(QString());
     const QString tooltip = m_isExpanded ? tr("Restore inspector to sidebar")
                                          : tr("Expand inspector to full window");
     m_expandButton->setToolTip(tooltip);
+    m_expandButton->setStatusTip(tooltip);
+    m_expandButton->setAccessibleName(tooltip);
 }
 
 void NodeInspectorWidget::mergeFormatOnSelection(const QTextCharFormat &format)
@@ -319,16 +336,35 @@ void NodeInspectorWidget::retranslateUi()
         m_titleLabel->setText(tr("Title"));
     }
     if (m_boldAction) {
-        m_boldAction->setText(tr("B"));
+        m_boldAction->setText(tr("Bold"));
+        const QString shortcutText = m_boldAction->shortcut().toString(QKeySequence::NativeText);
+        const QString tip = shortcutText.isEmpty() ? tr("Toggle bold formatting")
+                                                   : tr("Toggle bold formatting (%1)").arg(shortcutText);
+        m_boldAction->setToolTip(tip);
+        m_boldAction->setStatusTip(tip);
     }
     if (m_italicAction) {
-        m_italicAction->setText(tr("I"));
+        m_italicAction->setText(tr("Italic"));
+        const QString shortcutText = m_italicAction->shortcut().toString(QKeySequence::NativeText);
+        const QString tip = shortcutText.isEmpty() ? tr("Toggle italic formatting")
+                                                   : tr("Toggle italic formatting (%1)").arg(shortcutText);
+        m_italicAction->setToolTip(tip);
+        m_italicAction->setStatusTip(tip);
     }
     if (m_underlineAction) {
-        m_underlineAction->setText(tr("U"));
+        m_underlineAction->setText(tr("Underline"));
+        const QString shortcutText = m_underlineAction->shortcut().toString(QKeySequence::NativeText);
+        const QString tip = shortcutText.isEmpty() ? tr("Toggle underline formatting")
+                                                   : tr("Toggle underline formatting (%1)").arg(shortcutText);
+        m_underlineAction->setToolTip(tip);
+        m_underlineAction->setStatusTip(tip);
     }
     if (m_colorButton) {
         m_colorButton->setText(tr("Color"));
+        const QString tip = tr("Choose the text color");
+        m_colorButton->setToolTip(tip);
+        m_colorButton->setStatusTip(tip);
+        m_colorButton->setAccessibleName(tr("Text color"));
     }
     updateExpandButtonAppearance();
 }

--- a/resources/add_node.svg
+++ b/resources/add_node.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect x="1" y="1" width="14" height="14" rx="3" ry="3" fill="#4caf50"/>
+  <rect x="7" y="4" width="2" height="8" fill="#ffffff"/>
+  <rect x="4" y="7" width="8" height="2" fill="#ffffff"/>
+</svg>

--- a/resources/edit_script.svg
+++ b/resources/edit_script.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect x="2" y="1" width="10" height="14" rx="1" ry="1" fill="#ffffff" stroke="#424242" stroke-width="1"/>
+  <rect x="4" y="4" width="6" height="1" fill="#616161"/>
+  <rect x="4" y="6" width="5" height="1" fill="#616161"/>
+  <rect x="4" y="8" width="6" height="1" fill="#616161"/>
+  <path d="M9.5 9.5l3-3 2 2-3 3-2.5.5z" fill="#ff9800" stroke="#ef6c00" stroke-width="0.5" stroke-linejoin="round"/>
+</svg>

--- a/resources/export.svg
+++ b/resources/export.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path d="M3 2h10a1 1 0 0 1 1 1v3h-2V4H4v8h8v-2h2v3a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1z" fill="#546e7a"/>
+  <path d="M9 3l4 4-4 4V8H5V6h4z" fill="#29b6f6"/>
+</svg>

--- a/resources/palette.svg
+++ b/resources/palette.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path d="M8 1a7 7 0 0 0 0 14h1.5a1.5 1.5 0 1 0 0-3H8a2 2 0 0 1-2-2 1.5 1.5 0 0 1 1.5-1.5H9a2 2 0 0 0 2-2A5 5 0 0 0 8 1z" fill="#ffecb3" stroke="#fbc02d" stroke-width="0.5"/>
+  <circle cx="5" cy="5" r="1" fill="#ef5350"/>
+  <circle cx="9" cy="4" r="1" fill="#42a5f5"/>
+  <circle cx="6" cy="8" r="1" fill="#66bb6a"/>
+  <circle cx="10" cy="7" r="1" fill="#ab47bc"/>
+</svg>

--- a/resources/text_bold.svg
+++ b/resources/text_bold.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect x="3" y="2" width="6" height="12" rx="1" fill="#424242"/>
+  <path d="M7 2h3.5a2.5 2.5 0 0 1 0 5H7z" fill="#212121"/>
+  <path d="M7 7h3.5a2.5 2.5 0 0 1 0 5H7z" fill="#212121"/>
+</svg>

--- a/resources/text_italic.svg
+++ b/resources/text_italic.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path d="M6 2h7v2h-2.5l-2 8H11v2H4v-2h2.5l2-8H6z" fill="#424242"/>
+</svg>

--- a/resources/text_underline.svg
+++ b/resources/text_underline.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path d="M4 2h2v6a2 2 0 0 0 4 0V2h2v6a4 4 0 0 1-8 0z" fill="#424242"/>
+  <rect x="3" y="12" width="10" height="2" rx="1" fill="#212121"/>
+</svg>


### PR DESCRIPTION
## Summary
- add reusable SVG icons to the project resources and register them for Qt
- assign consistent icons, shortcuts, and translated tips to main window editing/export actions
- refresh the node inspector toolbar with iconography, shortcuts, and clearer tooltips/status text

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1d2b4b8dc832bb35ca729ec028879