### PR TITLE
Fix Qt project node map to store shared pointers

### DIFF
--- a/C++/visual_novel_editor/src/model/Project.cpp
+++ b/C++/visual_novel_editor/src/model/Project.cpp
@@ -14,11 +14,11 @@ Project::Project(QObject *parent)
 
 StoryNode *Project::addNode(StoryNode::Type type)
 {
-    auto node = std::make_unique<StoryNode>(generateId());
+    auto node = std::make_shared<StoryNode>(generateId());
     node->setType(type);
     node->setTitle(QStringLiteral("New Node"));
     StoryNode *nodePtr = node.get();
-    m_nodes.insert(node->id(), std::move(node));
+    m_nodes.insert(node->id(), node);
     emit changed();
     return nodePtr;
 }
@@ -120,7 +120,7 @@ void Project::fromJson(const QJsonObject &json)
     const QJsonArray nodesArray = json.value(QStringLiteral("nodes")).toArray();
     for (const QJsonValue &value : nodesArray) {
         const StoryNode node = StoryNode::fromJson(value.toObject());
-        auto nodePtr = std::make_unique<StoryNode>(node);
-        m_nodes.insert(nodePtr->id(), std::move(nodePtr));
+        auto nodePtr = std::make_shared<StoryNode>(node);
+        m_nodes.insert(nodePtr->id(), nodePtr);
     }
 }

--- a/C++/visual_novel_editor/src/model/Project.h
+++ b/C++/visual_novel_editor/src/model/Project.h
@@ -20,7 +20,7 @@ public:
 
     StoryNode *getNode(const QString &nodeId);
     const StoryNode *getNode(const QString &nodeId) const;
-    const QMap<QString, std::unique_ptr<StoryNode>> &nodes() const { return m_nodes; }
+    const QMap<QString, std::shared_ptr<StoryNode>> &nodes() const { return m_nodes; }
 
     [[nodiscard]] bool loadFromFile(const QString &fileName);
     [[nodiscard]] bool saveToFile(const QString &fileName) const;
@@ -31,7 +31,7 @@ signals:
     void changed();
 
 private:
-    QMap<QString, std::unique_ptr<StoryNode>> m_nodes;
+    QMap<QString, std::shared_ptr<StoryNode>> m_nodes;
 
     QJsonObject toJson() const;
     void fromJson(const QJsonObject &json);


### PR DESCRIPTION
## Summary
- replace Project's node storage with std::shared_ptr so nodes can be stored in QMap without invoking deleted unique_ptr copy operations
- update node creation and deserialization to create shared_ptr-managed StoryNode instances

## Testing
- cmake .. *(fails: missing Qt6 development files in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1dad94e04832bac468f120144c0d8