### PR TITLE
Add Yuuka LoRA preprocessing and training pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+.venv
+.env.local
+venv/
+.envrc
+.idea/
+.vscode/
+models/
+data/processed/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # -script-editor
+
+## Yuuka LoRA Training Utilities
+
+The `yuuka-ai` directory contains helper scripts for preparing dialogue data and
+training a LoRA adapter on top of Qwen/Qwen2.5-7B-Instruct within an 8 GB GPU
+budget.
+
+1. **Preprocess** the raw `yuuka_dialogues_zh.jsonl` file:
+
+   ```bash
+   python yuuka-ai/preprocess_data.py \
+       --input data/yuuka_dialogues_zh.jsonl \
+       --output-dir data/processed \
+       --eval-ratio 0.1
+   ```
+
+   This converts each dialogue turn into prompt/completion pairs where only the
+   `优香` responses contribute to the training loss.
+
+2. **Train** the LoRA adapter with 4-bit quantization:
+
+   ```bash
+   python yuuka-ai/train_lora.py \
+       --data-dir data/processed \
+       --output-dir models/qwen_yuuka_lora
+   ```
+
+   The script enables gradient checkpointing, paged AdamW 8-bit optimizers, and
+   LoRA adapters on the attention projection layers to remain within the target
+   memory footprint. Only the adapter weights are saved in the output directory.

--- a/yuuka-ai/preprocess_data.py
+++ b/yuuka-ai/preprocess_data.py
@@ -1,0 +1,157 @@
+"""Preprocess Yuuka dialogue data for supervised fine-tuning.
+
+This script converts dialogue logs stored in ``yuuka_dialogues_zh.jsonl``
+into prompt/completion pairs that follow the requirements discussed in the
+project brief:
+
+* Treat any message whose ``role`` is ``"优香"`` as the target response.
+* Treat every other message as context.
+* Build prompts that contain the full context with ``[角色]`` prefixes,
+  followed by the ``优香`` prefix ready for completion.
+* Store completions that contain the current ``优香`` reply terminated by
+  ``<eos>``. The training script will later replace the literal ``<eos>``
+  marker with the tokenizer specific end-of-sequence token.
+* Only the completion should contribute to the loss – the training script
+  masks the prompt portion with ``-100`` during collation.
+
+Usage
+-----
+python preprocess_data.py \
+    --input data/yuuka_dialogues_zh.jsonl \
+    --output-dir data/processed \
+    --eval-ratio 0.1
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence
+
+Sample = Dict[str, str]
+Message = Dict[str, str]
+
+
+def load_conversations(path: Path) -> Iterable[Sequence[Message]]:
+    """Yield message sequences from a JSONL dialogue log."""
+    with path.open("r", encoding="utf-8") as f:
+        for line_number, line in enumerate(f, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+                raise ValueError(
+                    f"Invalid JSON on line {line_number} of {path}: {exc}"
+                ) from exc
+            messages = obj.get("messages")
+            if not isinstance(messages, list):
+                raise ValueError(
+                    f"Expected a list of messages on line {line_number} of {path}."
+                )
+            yield messages
+
+
+def build_samples(messages: Sequence[Message]) -> List[Sample]:
+    """Convert a sequence of chat messages into training samples."""
+    context_lines: List[str] = []
+    samples: List[Sample] = []
+
+    for message in messages:
+        role = message.get("role")
+        content = (message.get("content") or "").strip()
+        if not role:
+            # Skip malformed messages but keep context intact.
+            continue
+
+        prefixed_line = f"[{role}] {content}\n"
+        if role == "优香":
+            prompt = "".join(context_lines) + "[优香] "
+            completion = f"{content}<eos>"
+            samples.append({"prompt": prompt, "completion": completion})
+        context_lines.append(prefixed_line)
+
+    return samples
+
+
+def split_samples(samples: List[Sample], eval_ratio: float, seed: int = 42) -> Dict[str, List[Sample]]:
+    """Shuffle and split samples into train/eval subsets."""
+    if not samples:
+        raise ValueError("No samples generated from the provided conversations.")
+
+    rng = random.Random(seed)
+    rng.shuffle(samples)
+
+    eval_size = int(len(samples) * eval_ratio)
+    eval_size = max(1, eval_size) if 0 < eval_ratio < 1.0 else 0
+    eval_samples = samples[:eval_size]
+    train_samples = samples[eval_size:]
+
+    if not train_samples:
+        raise ValueError("Evaluation split is too large; no training samples left.")
+
+    return {"train": train_samples, "eval": eval_samples}
+
+
+def dump_samples(samples: Iterable[Sample], path: Path) -> None:
+    """Write samples to ``path`` in JSONL format."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for sample in samples:
+            json.dump(sample, f, ensure_ascii=False)
+            f.write("\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Preprocess Yuuka dialogue data")
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=Path("data/yuuka_dialogues_zh.jsonl"),
+        help="Path to the raw Yuuka dialogue JSONL file.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("data/processed"),
+        help="Directory where processed JSONL files will be written.",
+    )
+    parser.add_argument(
+        "--eval-ratio",
+        type=float,
+        default=0.1,
+        help="Fraction of samples to reserve for evaluation (0–1).",
+    )
+    parser.add_argument(
+        "--seed", type=int, default=42, help="Random seed for data shuffling."
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    conversations = load_conversations(args.input)
+
+    all_samples: List[Sample] = []
+    for messages in conversations:
+        all_samples.extend(build_samples(messages))
+
+    splits = split_samples(all_samples, args.eval_ratio, seed=args.seed)
+
+    train_path = args.output_dir / "train.jsonl"
+    eval_path = args.output_dir / "eval.jsonl"
+
+    dump_samples(splits["train"], train_path)
+    if splits["eval"]:
+        dump_samples(splits["eval"], eval_path)
+
+    print(f"Wrote {len(splits['train'])} training samples to {train_path}")
+    if splits["eval"]:
+        print(f"Wrote {len(splits['eval'])} evaluation samples to {eval_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/yuuka-ai/train_lora.py
+++ b/yuuka-ai/train_lora.py
@@ -1,0 +1,207 @@
+"""Fine-tune Qwen on Yuuka dialogues with parameter-efficient LoRA."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict, List
+
+import torch
+from datasets import load_dataset
+from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training
+from transformers import (AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig,
+                          Trainer, TrainingArguments)
+
+DEFAULT_MODEL_NAME = "Qwen/Qwen2.5-7B-Instruct"
+DEFAULT_DATA_DIR = Path("data/processed")
+DEFAULT_OUTPUT_DIR = Path("models/qwen_yuuka_lora")
+MAX_SEQ_LEN = 1024
+
+
+def get_tokenizer(model_name: str):
+    tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    tokenizer.padding_side = "right"
+    return tokenizer
+
+
+def load_model(model_name: str):
+    quant_config = BitsAndBytesConfig(
+        load_in_4bit=True,
+        bnb_4bit_quant_type="nf4",
+        bnb_4bit_use_double_quant=True,
+        bnb_4bit_compute_dtype=torch.float16,
+    )
+
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name,
+        quantization_config=quant_config,
+        device_map="auto",
+        trust_remote_code=True,
+    )
+    model = prepare_model_for_kbit_training(model)
+    model.config.use_cache = False
+
+    lora_config = LoraConfig(
+        r=16,
+        lora_alpha=32,
+        lora_dropout=0.05,
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+        task_type="CAUSAL_LM",
+    )
+    model = get_peft_model(model, lora_config)
+    model.print_trainable_parameters()
+    return model
+
+
+class PromptCompletionCollator:
+    def __init__(self, tokenizer, max_seq_len: int):
+        self.tokenizer = tokenizer
+        self.max_seq_len = max_seq_len
+
+    def __call__(self, batch: List[Dict[str, str]]) -> Dict[str, torch.Tensor]:
+        input_ids = []
+        labels = []
+        attention_masks = []
+
+        for sample in batch:
+            prompt = sample["prompt"]
+            completion = sample["completion"].replace("<eos>", self.tokenizer.eos_token)
+
+            prompt_ids = self.tokenizer.encode(prompt, add_special_tokens=False)
+            completion_ids = self.tokenizer.encode(
+                completion, add_special_tokens=False
+            )
+
+            combined_ids = prompt_ids + completion_ids
+            combined_labels = [-100] * len(prompt_ids) + completion_ids
+
+            if len(combined_ids) > self.max_seq_len:
+                combined_ids = combined_ids[: self.max_seq_len]
+                combined_labels = combined_labels[: self.max_seq_len]
+
+            attention_mask = [1] * len(combined_ids)
+
+            # Pad to max length for the batch.
+            input_ids.append(combined_ids)
+            labels.append(combined_labels)
+            attention_masks.append(attention_mask)
+
+        batch_max = max(len(ids) for ids in input_ids)
+        padded_input_ids = []
+        padded_labels = []
+        padded_masks = []
+
+        for ids, lbls, mask in zip(input_ids, labels, attention_masks):
+            pad_len = batch_max - len(ids)
+            padded_input_ids.append(ids + [self.tokenizer.pad_token_id] * pad_len)
+            padded_masks.append(mask + [0] * pad_len)
+            padded_labels.append(lbls + [-100] * pad_len)
+
+        return {
+            "input_ids": torch.tensor(padded_input_ids, dtype=torch.long),
+            "attention_mask": torch.tensor(padded_masks, dtype=torch.long),
+            "labels": torch.tensor(padded_labels, dtype=torch.long),
+        }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train a LoRA adapter for Yuuka")
+    parser.add_argument(
+        "--model-name",
+        type=str,
+        default=DEFAULT_MODEL_NAME,
+        help="Base model to fine-tune.",
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=DEFAULT_DATA_DIR,
+        help="Directory with train.jsonl and eval.jsonl produced by preprocess_data.py.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help="Where to store the trained LoRA adapter.",
+    )
+    parser.add_argument(
+        "--num-epochs", type=float, default=3, help="Number of training epochs."
+    )
+    parser.add_argument(
+        "--eval-steps",
+        type=int,
+        default=100,
+        help="Run evaluation every N steps (0 disables step evaluations).",
+    )
+    parser.add_argument(
+        "--logging-steps", type=int, default=10, help="Logging interval in steps."
+    )
+    return parser.parse_args()
+
+
+def load_data(data_dir: Path):
+    data_files = {"train": data_dir / "train.jsonl"}
+    eval_path = data_dir / "eval.jsonl"
+    if eval_path.exists():
+        data_files["validation"] = eval_path
+    dataset = load_dataset("json", data_files={k: str(v) for k, v in data_files.items()})
+    return dataset
+
+
+def main() -> None:
+    args = parse_args()
+
+    tokenizer = get_tokenizer(args.model_name)
+    model = load_model(args.model_name)
+
+    dataset = load_data(args.data_dir)
+
+    collator = PromptCompletionCollator(tokenizer, max_seq_len=MAX_SEQ_LEN)
+
+    has_validation = "validation" in dataset
+    if has_validation:
+        evaluation_strategy = "steps" if args.eval_steps > 0 else "epoch"
+    else:
+        evaluation_strategy = "no"
+    eval_steps = args.eval_steps if has_validation and args.eval_steps > 0 else None
+
+    training_args = TrainingArguments(
+        output_dir=str(args.output_dir),
+        per_device_train_batch_size=1,
+        gradient_accumulation_steps=8,
+        gradient_checkpointing=True,
+        learning_rate=1e-4,
+        lr_scheduler_type="cosine",
+        warmup_ratio=0.03,
+        optim="paged_adamw_8bit",
+        num_train_epochs=args.num_epochs,
+        logging_steps=args.logging_steps,
+        evaluation_strategy=evaluation_strategy,
+        eval_steps=eval_steps,
+        save_strategy="epoch",
+        save_total_limit=2,
+        bf16=torch.cuda.is_available(),
+        dataloader_num_workers=2,
+        report_to=[],
+    )
+
+    trainer = Trainer(
+        model=model,
+        tokenizer=tokenizer,
+        args=training_args,
+        train_dataset=dataset["train"],
+        eval_dataset=dataset.get("validation"),
+        data_collator=collator,
+    )
+
+    trainer.train()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    trainer.model.save_pretrained(args.output_dir)
+    tokenizer.save_pretrained(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add preprocessing script that builds prompt/completion pairs from Yuuka dialogues with context-only masking
- implement LoRA training entry point using Qwen2.5-7B-Instruct with 4-bit quantization and attention-only adapters
- document the workflow and ignore generated artifacts

## Testing
- python -m py_compile yuuka-ai/preprocess_data.py yuuka-ai/train_lora.py

------
https://chatgpt.com/codex/tasks/task_e_68e659439f74832bb8951ebe79f238ad